### PR TITLE
Update postgres.php describe to avoid information_schema.columns

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -201,10 +201,42 @@ class Postgres extends DboSource {
 
 		if ($fields === null) {
 			$cols = $this->_execute(
-				"SELECT DISTINCT table_schema AS schema, column_name AS name, data_type AS type, is_nullable AS null,
-					column_default AS default, ordinal_position AS position, character_maximum_length AS char_length,
-					character_octet_length AS oct_length FROM information_schema.columns
-				WHERE table_name = ? AND table_schema = ?  ORDER BY position",
+		"WITH pg_attribute_local AS (SELECT * FROM pg_attribute WHERE attrelid = (? || '.' || ?)::regclass AND attnum > 0 )
+			SELECT
+			    nc.nspname::information_schema.sql_identifier AS schema,
+			    a.attname::information_schema.sql_identifier AS name,
+			    CASE
+			        WHEN t.typtype = 'd'::"char" THEN
+			        CASE
+			            WHEN bt.typelem <> 0::oid AND bt.typlen = '-1'::integer THEN 'ARRAY'::text
+			            WHEN nbt.nspname = 'pg_catalog'::name THEN format_type(t.typbasetype, NULL::integer)
+			            ELSE 'USER-DEFINED'::text
+			        END
+			        ELSE
+			        CASE
+			            WHEN t.typelem <> 0::oid AND t.typlen = '-1'::integer THEN 'ARRAY'::text
+			            WHEN nt.nspname = 'pg_catalog'::name THEN format_type(a.atttypid, NULL::integer)
+			            ELSE 'USER-DEFINED'::text
+			        END
+			    END::information_schema.character_data AS type,
+			    CASE
+			        WHEN a.attnotnull OR t.typtype = 'd'::"char" AND t.typnotnull THEN 'NO'::text
+			        ELSE 'YES'::text
+			    END::information_schema.yes_or_no AS null,
+			    pg_get_expr(ad.adbin, ad.adrelid)::information_schema.character_data AS default,
+			    a.attnum::information_schema.cardinal_number AS position,
+			    information_schema._pg_char_max_length(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS char_length,
+			    information_schema._pg_char_octet_length(information_schema._pg_truetypid(a.*, t.*), information_schema._pg_truetypmod(a.*, t.*))::information_schema.cardinal_number AS oct_length
+			FROM pg_attribute_local a
+			LEFT JOIN pg_attrdef ad ON a.attrelid = ad.adrelid AND a.attnum = ad.adnum
+			     JOIN (pg_class c
+			     JOIN pg_namespace nc ON c.relnamespace = nc.oid) ON a.attrelid = c.oid
+			     JOIN (pg_type t
+			     JOIN pg_namespace nt ON t.typnamespace = nt.oid) ON a.atttypid = t.oid
+			LEFT JOIN (pg_type bt
+			     JOIN pg_namespace nbt ON bt.typnamespace = nbt.oid) ON t.typtype = 'd'::"char" AND t.typbasetype = bt.oid
+			WHERE NOT pg_is_other_temp_schema(nc.oid) AND a.attnum > 0 AND NOT a.attisdropped AND (c.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char"])) AND (pg_has_role(c.relowner, 'USAGE'::text) OR has_column_privilege(c.oid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES'::text))
+			ORDER BY a.attnum",
 				array($table, $this->config['schema'])
 			);
 


### PR DESCRIPTION
Calls to information_schema.columns directly had significant overhead causing slowdowns, using a cte to filter by the schema and table name before joining to other relations (joins are the same as in information_schema.columns with a couple unneeded ones eliminated)  speeds the queries significantly.
